### PR TITLE
Add mcrypt_create_iv as fallback if openSSL ain't install in phpsecRand.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /logs
 /.project
 /examples.php
+/nbproject

--- a/phpsec/phpsec.rand.php
+++ b/phpsec/phpsec.rand.php
@@ -31,7 +31,15 @@ class phpsecRand {
         return $rnd;
       }
     }
+    
     /* Either we dont have the OpenSSL library or the data returned was not
+     * considered secure. Fall back on this less secure code. */
+    if(function_exists('mcrypt_create_iv')) {
+      $rnd = mcrypt_create_iv($len, MCRYPT_RAND);
+      return $rnd;
+    }
+    
+    /* Either we dont have the MCrypt library and OpenSSL library or the data returned was not
      * considered secure. Fall back on this less secure code. */
     $rnd = '';
     for ($i=0;$i<$len;$i++) {


### PR DESCRIPTION
Add mcrypt_create_iv as fallback if openSSL ain't install in phpsecRand.
