### PR TITLE
fixing a few bugs in the Hash class for generating other hash types, upd...

### DIFF
--- a/lib/phpSec/Crypt/Hash.php
+++ b/lib/phpSec/Crypt/Hash.php
@@ -64,7 +64,7 @@ class Hash {
   /**
    * Salt charsets.
    */
-  public static $charsets = array(
+  public $charsets = array(
     'itoa64' => './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
   );
 
@@ -87,18 +87,18 @@ class Hash {
    */
   public function create($str) {
 
-    $rnd = $this->psl['crypt/rand'];
+    $rand = $this->psl['crypt/rand'];
     $crypto = $this->psl['crypt/crypto'];
 
     switch($this->method) {
       case self::BCRYPT:
-        $saltRnd = $rnd->str(22, $this->charsets['itoa64']);
+        $saltRnd = $rand->str(22, $this->charsets['itoa64']);
         $salt = sprintf('$2a$%s$%s', $this->bcrypt_cost, $saltRnd);
         $hash = crypt($str, $salt);
       break;
 
       case self::PBKDF2:
-        $salt = $rnd->bytes(64);
+        $salt = $rand->bytes(64);
         $hash = $crypto->pbkdf2($str, $salt, $this->pbkdf2_c, $this->pbkdf2_dkLen, $this->pbkdf2_prf);
 
         $hash = sprintf('$pbkdf2$c=%s&dk=%s&f=%s$%s$%s',
@@ -254,7 +254,7 @@ class Hash {
   	} while (--$count);
 
   	$len = strlen($hash);
-  	$output = $setting . self::_b64Encode($hash, $len);
+  	$output = $setting . $this->b64Encode($hash, $len);
   	$expected = 12 + ceil((8 * $len) / 6);
 
   	return substr($output, 0, $expected);

--- a/tests/phpSec/Crypt/HashTest.php
+++ b/tests/phpSec/Crypt/HashTest.php
@@ -1,7 +1,10 @@
 <?php
 class HashTest extends PHPUnit_Framework_TestCase {
 
-  public function testHash() {
+  /**
+   * Test the creation of the default hash (PBKDF2)
+   */
+  public function testDefaultHash() {
     $psl = new \phpSec\Core();
 
     $hash = $psl['crypt/hash'];
@@ -10,5 +13,53 @@ class HashTest extends PHPUnit_Framework_TestCase {
 
     $this->assertTrue($hash->check($str, $pwHash));
 
+  }
+
+  public function testBcryptHash()
+  {
+    $psl = new \phpSec\Core();
+
+    $hash = $psl['crypt/hash'];
+    $hash->method = \phpSec\Crypt\Hash::BCRYPT;
+    $str = 'some string';
+    $pwHash = $hash->create($str);
+
+    $this->assertTrue($hash->check($str, $pwHash));
+  }
+
+  public function testDrupalHash()
+  {
+    $psl = new \phpSec\Core();
+
+    $hash = $psl['crypt/hash'];
+    $hash->method = \phpSec\Crypt\Hash::DRUPAL;
+    $str = 'some string';
+    $pwHash = $hash->create($str);
+
+    $this->assertTrue($hash->check($str, $pwHash));
+  }
+
+  public function testSha256Hash()
+  {
+    $psl = new \phpSec\Core();
+
+    $hash = $psl['crypt/hash'];
+    $hash->method = \phpSec\Crypt\Hash::SHA256;
+    $str = 'some string';
+    $pwHash = $hash->create($str);
+
+    $this->assertTrue($hash->check($str, $pwHash));
+  }
+
+  public function testSha512Hash()
+  {
+    $psl = new \phpSec\Core();
+
+    $hash = $psl['crypt/hash'];
+    $hash->method = \phpSec\Crypt\Hash::SHA512;
+    $str = 'some string';
+    $pwHash = $hash->create($str);
+
+    $this->assertTrue($hash->check($str, $pwHash));
   }
 }


### PR DESCRIPTION
...ating tests to add a few more checks
1. Adding tests for other hash generation types (was just the default)
2. Fixed $this->charsets to make it non-static
3. Changed b64Encode() call to be non-static
4. Removed some extra spacing
